### PR TITLE
Add WebSocket event stream endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_urlencoded",
  "sha1",
  "sync_wrapper 1.0.1",
  "tokio",
@@ -855,6 +856,18 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0.81"
 clap = { version = "4.5.4", features = ["derive"] }
 serde = "1.0.203"
 tokio = { version = "1.38.0", features = ["full"] }
-axum = { version = "0.7.5", default-features = false, features = ["http1", "ws"] }
+axum = { version = "0.7.5", default-features = false, features = ["http1", "ws", "query"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 futures-util = "0.3.30"
 rust-embed = "8.4.0"

--- a/assets/index.html
+++ b/assets/index.html
@@ -33,7 +33,7 @@
 
   <script>
     const loc = window.location;
-    const src = loc.protocol.replace("http", "ws") + '//' + loc.host + '/ws/live';
+    const src = loc.protocol.replace("http", "ws") + '//' + loc.host + '/ws/alis';
 
     const opts = {
       logger: console,


### PR DESCRIPTION
This new endpoint, `/ws/events`, allows the client to subscribe to events that happen in ht.

Query param `sub` should be set to a comma-separated list of desired events. E.g. `/ws/events?sub=init,snapshot`.

Events are delivered as JSON encoded strings, using WebSocket text message type.

Every event contains 2 fields:

- `type` - type of event
- `data` - associated data, specific to each event type

Supported events:

- `init` - similar to `snapshot` but sent once, as the first event after connection
- `stdout` - terminal output
- `resize` - terminal resize
- `snapshot` - view snapshot taken (e.g. with `getView`)