### PR TITLE
added ht as a flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,28 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
+
+        ht = pkgs.rustPlatform.buildRustPackage {
+          pname = "ht";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk.frameworks.Foundation
+          ];
+        };
       in
       {
+        packages = {
+          ht = ht;
+          default = ht;
+        };
+
         devShells.default = pkgs.mkShell {
           nativeBuildInputs =
             with pkgs;


### PR DESCRIPTION
Having this as an output is handy because now I can put it in my devshell like so:

```nix
# flake.nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
    ht.url = "github:MatrixManAtYrService/ht";
  };
  outputs = { self, nixpkgs, flake-utils, ht }:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = import nixpkgs {
          inherit system;
        };
      in
      {
        devShells.default = pkgs.mkShell {
          buildInputs = [
            ht.packages.${system}.ht
          ];
        };
      });
}
```

It works on MacOS, I'll un-draft it once I've tested it on Linux