### PR TITLE
added 'pid' event

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ pub struct Subscription {
     snapshot: bool,
     resize: bool,
     output: bool,
+    pid: bool,
 }
 
 impl FromStr for Subscription {
@@ -22,6 +23,7 @@ impl FromStr for Subscription {
                 "output" => sub.output = true,
                 "resize" => sub.resize = true,
                 "snapshot" => sub.snapshot = true,
+                "pid" => sub.pid = true,
                 _ => return Err(format!("invalid event name: {event}")),
             }
         }

--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -103,6 +103,8 @@ async fn alis_message(
 
         Ok(Snapshot(_, _, _, _)) => None,
 
+        Ok(Pid(_, _)) => None,
+
         Err(e) => Some(Err(axum::Error::new(e))),
     }
 }
@@ -162,6 +164,7 @@ async fn event_stream_message(
         Ok(e @ Output(_, _)) if sub.output => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Resize(_, _, _)) if sub.resize => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Snapshot(_, _, _, _)) if sub.snapshot => Some(Ok(json_message(e.to_json()))),
+        Ok(e @ Pid(_, _)) if sub.pid => Some(Ok(json_message(e.to_json()))),
         Ok(_) => None,
         Err(e) => Some(Err(axum::Error::new(e))),
     }

--- a/src/api/stdio.rs
+++ b/src/api/stdio.rs
@@ -68,6 +68,10 @@ pub async fn start(
                         println!("{}", e.to_json().to_string());
                     }
 
+                    Some(Ok(e @ Pid(_, _))) if sub.pid => {
+                        println!("{}", e.to_json().to_string());
+                    }
+
                     Some(_) => (),
 
                     None => break

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,13 @@ async fn main() -> Result<()> {
     let (output_tx, output_rx) = mpsc::channel(1024);
     let (command_tx, command_rx) = mpsc::channel(1024);
     let (clients_tx, clients_rx) = mpsc::channel(1);
+    let (pid_tx, pid_rx) = mpsc::channel(1);
 
     start_http_api(cli.listen, clients_tx.clone()).await?;
     let api = start_stdio_api(command_tx, clients_tx, cli.subscribe.unwrap_or_default());
-    let pty = start_pty(cli.command, &cli.size, input_rx, output_tx)?;
+    let pty = start_pty(cli.command, &cli.size, input_rx, output_tx, pid_tx)?;
     let session = build_session(&cli.size);
-    run_event_loop(output_rx, input_tx, command_rx, clients_rx, session, api).await?;
+    run_event_loop(output_rx, input_tx, command_rx, clients_rx, pid_rx, session, api).await?;
     pty.await?
 }
 
@@ -46,12 +47,13 @@ fn start_pty(
     size: &cli::Size,
     input_rx: mpsc::Receiver<Vec<u8>>,
     output_tx: mpsc::Sender<Vec<u8>>,
+    pid_tx: mpsc::Sender<i32>,
 ) -> Result<JoinHandle<Result<()>>> {
     let command = command.join(" ");
     eprintln!("launching \"{}\" in terminal of size {}", command, size);
 
     Ok(tokio::spawn(pty::spawn(
-        command, size, input_rx, output_tx,
+        command, size, input_rx, output_tx, pid_tx,
     )?))
 }
 
@@ -72,6 +74,7 @@ async fn run_event_loop(
     input_tx: mpsc::Sender<Vec<u8>>,
     mut command_rx: mpsc::Receiver<Command>,
     mut clients_rx: mpsc::Receiver<session::Client>,
+    mut pid_rx: mpsc::Receiver<i32>,
     mut session: Session,
     mut api_handle: JoinHandle<Result<()>>,
 ) -> Result<()> {
@@ -89,6 +92,12 @@ async fn run_event_loop(
                         eprintln!("process exited, shutting down...");
                         break;
                     }
+                }
+            }
+
+            pid = pid_rx.recv() => {
+                if let Some(pid) = pid {
+                    session.emit_pid(pid);
                 }
             }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -20,11 +20,20 @@ pub fn spawn(
     winsize: &pty::Winsize,
     input_rx: mpsc::Receiver<Vec<u8>>,
     output_tx: mpsc::Sender<Vec<u8>>,
+    pid_tx: mpsc::Sender<i32>,
 ) -> Result<impl Future<Output = Result<()>>> {
     let result = unsafe { pty::forkpty(Some(winsize), None) }?;
 
     match result.fork_result {
-        ForkResult::Parent { child } => Ok(drive_child(child, result.master, input_rx, output_tx)),
+        ForkResult::Parent { child } => {
+            let pid = child.as_raw();
+
+            tokio::spawn(async move {
+                let _ = pid_tx.try_send(pid);
+            });
+
+            Ok(drive_child(child, result.master, input_rx, output_tx))
+        },
 
         ForkResult::Child => {
             exec(command)?;


### PR DESCRIPTION
I wanted to be able to send signals to the subprocess, so I added an event which would show me its pid.

Tested like so:

```
❯ nix develop -c cargo build
❯ ./target/release/ht --subscribe pid
launching "bash" in terminal of size 120x40
{"data":{"pid":9277},"type":"pid"}
```