### PR TITLE
Added exitCode event and `--no-exit` flag

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -8,6 +8,7 @@ pub struct Subscription {
     snapshot: bool,
     resize: bool,
     output: bool,
+    exit_code: bool,
 }
 
 impl FromStr for Subscription {
@@ -22,6 +23,7 @@ impl FromStr for Subscription {
                 "output" => sub.output = true,
                 "resize" => sub.resize = true,
                 "snapshot" => sub.snapshot = true,
+                "exitCode" => sub.exit_code = true,
                 _ => return Err(format!("invalid event name: {event}")),
             }
         }

--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -103,6 +103,8 @@ async fn alis_message(
 
         Ok(Snapshot(_, _, _, _)) => None,
 
+        Ok(ExitCode(_, _)) => None,
+
         Err(e) => Some(Err(axum::Error::new(e))),
     }
 }
@@ -162,6 +164,7 @@ async fn event_stream_message(
         Ok(e @ Output(_, _)) if sub.output => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Resize(_, _, _)) if sub.resize => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Snapshot(_, _, _, _)) if sub.snapshot => Some(Ok(json_message(e.to_json()))),
+        Ok(e @ ExitCode(_, _)) if sub.exit_code => Some(Ok(json_message(e.to_json()))),
         Ok(_) => None,
         Err(e) => Some(Err(axum::Error::new(e))),
     }

--- a/src/api/stdio.rs
+++ b/src/api/stdio.rs
@@ -68,6 +68,10 @@ pub async fn start(
                         println!("{}", e.to_json().to_string());
                     }
 
+                    Some(Ok(e @ ExitCode(_, _))) if sub.exit_code => {
+                        println!("{}", e.to_json().to_string());
+                    }
+
                     Some(_) => (),
 
                     None => break

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,10 @@ pub struct Cli {
     /// Subscribe to events
     #[arg(long, value_name = "EVENTS")]
     pub subscribe: Option<Subscription>,
+    
+    /// Keep terminal session open after subprocess exits (send "Enter" key to fully quit)
+    #[arg(long)]
+    pub no_exit: bool,
 }
 
 impl Cli {


### PR DESCRIPTION
Hi, thanks for `ht`, it's super useful.

I wanted to see what the terminal looked like even after the subprocess exited, so I added `--no-exit` which prevents ht from exiting immediately.  Sending a second "Enter") causes ht to exit.

I also wanted to know the exit code, so I added an event for that.  These are best used together because maybe ht exits so quickly that the exitCode event doesn't appear.

Tested like so:
```
❯ ./target/release/ht --subscribe exitCode --no-exit
launching "bash" in terminal of size 120x40
{"type": "sendKeys", "keys": ["exit 123", "Enter"]}
sending HUP signal to the child process
Process exited. Send {"type": "sendKeys", "keys": ["Enter"]} to exit...
waiting for the child process to exit
{"data":{"exitCode":123},"type":"exitCode"}
{"type": "sendKeys", "keys": ["Enter"]}
Exiting...
```