### PR TITLE
added 'Backspace' key support

### DIFF
--- a/src/api/stdio.rs
+++ b/src/api/stdio.rs
@@ -142,6 +142,7 @@ fn parse_key(key: String) -> InputSeq {
         "C--" | "C-_" => "\x1f",
         "Tab" => "\x09",   // same as C-i
         "Enter" => "\x0d", // same as C-m
+        "Backspace" => "\x7f", // DEL character
         "Space" => " ",
         "Left" => return cursor_key("\x1b[D", "\x1bOD"),
         "Right" => return cursor_key("\x1b[C", "\x1bOC"),
@@ -309,6 +310,7 @@ mod test {
             ["C-Space", "\x00"],
             ["Tab", "\x09"],
             ["Enter", "\x0d"],
+            ["Backspace", "\x7f"],
             ["Escape", "\x1b"],
             ["^[", "\x1b"],
             ["C-Left", "\x1b[1;5D"],


### PR DESCRIPTION
I noticed that there was no backspace, so I added one.

Tested like this:

```
❯ ./target/release/ht --size 10x2 --subscribe snapshot
launching "bash" in terminal of size 10x2
{"type": "sendKeys", "keys": ["ABCD", "Backspace", "Backspace", "EF"]}
{ "type": "takeSnapshot" }
{"data":{"cols":10,"rows":2,"seq":"\u001b[0mbash-5.2$ \u001b[0mABEF      5W9`\u001b[W1;1H\u001b[0m\u001b7?1047h1;1H\u001b[0m\u001b7?1047l1;2r2;5H\u001b[0m","text":"bash-5.2$ \nABEF      "},"type":"snapshot"}
```

Notice the `ABEF` in the text field, indicating that `CD` was removed.