### PR TITLE
Add pid field to the init event

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ Same as `snapshot` event (see below) but sent only once, as the first event
 after ht's start (when sent to STDOUT) and upon establishing of WebSocket
 connection.
 
+In addition to the fields from `snapshot` event this one includes:
+
+- `pid` - PID of the top-level process started by ht (e.g. PID of bash)
+
 #### `output`
 
 Terminal output. Sent when an application (e.g. shell) running under ht prints

--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -86,7 +86,7 @@ async fn alis_message(
     use session::Event::*;
 
     match event {
-        Ok(Init(time, cols, rows, seq, _text)) => Some(Ok(json_message(json!({
+        Ok(Init(time, cols, rows, _pid, seq, _text)) => Some(Ok(json_message(json!({
             "time": time,
             "cols": cols,
             "rows": rows,
@@ -158,7 +158,7 @@ async fn event_stream_message(
     use session::Event::*;
 
     match event {
-        Ok(e @ Init(_, _, _, _, _)) if sub.init => Some(Ok(json_message(e.to_json()))),
+        Ok(e @ Init(_, _, _, _, _, _)) if sub.init => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Output(_, _)) if sub.output => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Resize(_, _, _)) if sub.resize => Some(Ok(json_message(e.to_json()))),
         Ok(e @ Snapshot(_, _, _, _)) if sub.snapshot => Some(Ok(json_message(e.to_json()))),

--- a/src/api/stdio.rs
+++ b/src/api/stdio.rs
@@ -52,7 +52,7 @@ pub async fn start(
                 use session::Event::*;
 
                 match event {
-                    Some(Ok(e @ Init(_, _, _, _, _))) if sub.init => {
+                    Some(Ok(e @ Init(_, _, _, _, _, _))) if sub.init => {
                         println!("{}", e.to_json());
                     }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -20,11 +20,14 @@ pub fn spawn(
     winsize: &pty::Winsize,
     input_rx: mpsc::Receiver<Vec<u8>>,
     output_tx: mpsc::Sender<Vec<u8>>,
-) -> Result<impl Future<Output = Result<()>>> {
+) -> Result<(i32, impl Future<Output = Result<()>>)> {
     let result = unsafe { pty::forkpty(Some(winsize), None) }?;
 
     match result.fork_result {
-        ForkResult::Parent { child } => Ok(drive_child(child, result.master, input_rx, output_tx)),
+        ForkResult::Parent { child } => Ok((
+            child.as_raw(),
+            drive_child(child, result.master, input_rx, output_tx),
+        )),
 
         ForkResult::Child => {
             exec(command)?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,11 +12,12 @@ pub struct Session {
     stream_time: f64,
     start_time: Instant,
     last_event_time: Instant,
+    pid: i32,
 }
 
 #[derive(Clone)]
 pub enum Event {
-    Init(f64, usize, usize, String, String),
+    Init(f64, usize, usize, i32, String, String),
     Output(f64, String),
     Resize(f64, usize, usize),
     Snapshot(usize, usize, String, String),
@@ -30,7 +31,7 @@ pub struct Subscription {
 }
 
 impl Session {
-    pub fn new(cols: usize, rows: usize) -> Self {
+    pub fn new(cols: usize, rows: usize, pid: i32) -> Self {
         let (broadcast_tx, _) = broadcast::channel(1024);
         let now = Instant::now();
 
@@ -40,6 +41,7 @@ impl Session {
             stream_time: 0.0,
             start_time: now,
             last_event_time: now,
+            pid,
         }
     }
 
@@ -81,6 +83,7 @@ impl Session {
             self.elapsed_time(),
             cols,
             rows,
+            self.pid,
             self.vt.dump(),
             self.text_view(),
         );
@@ -107,11 +110,12 @@ impl Session {
 impl Event {
     pub fn to_json(&self) -> serde_json::Value {
         match self {
-            Event::Init(_time, cols, rows, seq, text) => json!({
+            Event::Init(_time, cols, rows, pid, seq, text) => json!({
                 "type": "init",
                 "data": json!({
                     "cols": cols,
                     "rows": rows,
+                    "pid": pid,
                     "seq": seq,
                     "text": text,
                 })


### PR DESCRIPTION
Alternative to #18.

```
$ ht --subscribe init
aunching "bash" in terminal of size 120x40
{"data":{"cols":120,"pid":159854,"rows":40,"seq":"...","text":"..."},"type":"init"}
```