### PR TITLE
Add mouse support for TUI interaction (partially addresses #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,50 @@ specifying new width (`cols`) and height (`rows`).
 
 This command triggers `resize` event.
 
+#### mouse
+
+`mouse` command allows sending mouse events to the application running in the
+virtual terminal.
+
+```json
+{ "type": "mouse", "event": "click", "button": "left", "row": 10, "col": 25 }
+{ "type": "mouse", "event": "press", "button": "right", "row": 5, "col": 15, "control": true }
+{ "type": "mouse", "event": "drag", "button": "left", "row": 12, "col": 30 }
+{ "type": "mouse", "event": "release", "button": "left", "row": 12, "col": 30 }
+```
+
+Event types:
+- `press` - mouse button pressed down
+- `release` - mouse button released
+- `drag` - mouse motion while button is held down
+- `click` - convenience shorthand that sends both press and release events
+
+Supported buttons:
+- `left`, `middle`, `right` - standard mouse buttons
+- `wheel_up`, `wheel_down` - scroll wheel events
+
+Coordinates are 1-indexed, meaning row 1, col 1 represents the top-left cell of
+the terminal. Coordinates exceeding the current terminal size will trigger a
+warning but are still sent to the application.
+
+Optional modifier keys can be specified as boolean fields (default `false`):
+- `shift` - Shift key held during mouse event
+- `alt` - Alt/Option key held during mouse event
+- `control` - Control key held during mouse event
+
+Example with modifiers:
+```json
+{ "type": "mouse", "event": "click", "button": "left", "row": 10, "col": 25, "shift": true, "control": true }
+```
+
+**Important**: Mouse events use the SGR extended mouse protocol (`\x1b[<` format).
+The application running in the terminal must enable mouse tracking for these
+events to have any effect. Most modern TUI applications (vim with `:set mouse=a`,
+tmux, less, emacs, etc.) support mouse tracking and will enable it automatically
+when needed.
+
+This command doesn't trigger any event.
+
 ### WebSocket API
 
 The WebSocket API currently provides 2 endpoints:

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,8 @@
 #[derive(Debug)]
 pub enum Command {
     Input(Vec<InputSeq>),
+    Mouse(MouseEvent),
+    MouseClick(MouseEvent), // Convenience: sends press then release
     Snapshot,
     Resize(usize, usize),
 }
@@ -27,4 +29,71 @@ fn seq_as_bytes(seq: &InputSeq, app_mode: bool) -> &[u8] {
         (InputSeq::Cursor(seq1, _seq2), false) => seq1.as_bytes(),
         (InputSeq::Cursor(_seq1, seq2), true) => seq2.as_bytes(),
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct MouseEvent {
+    pub event_type: MouseEventType,
+    pub button: MouseButton,
+    pub row: usize,
+    pub col: usize,
+    pub modifiers: MouseModifiers,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MouseEventType {
+    Press,
+    Release,
+    Drag,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MouseButton {
+    Left,
+    Middle,
+    Right,
+    WheelUp,
+    WheelDown,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MouseModifiers {
+    pub shift: bool,
+    pub alt: bool,
+    pub control: bool,
+}
+
+pub fn mouse_to_bytes(event: &MouseEvent) -> Vec<u8> {
+    // Base button encoding per SGR protocol
+    let mut btn = match event.button {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+        MouseButton::WheelUp => 64,
+        MouseButton::WheelDown => 65,
+    };
+
+    // Add modifier bits
+    if event.modifiers.shift {
+        btn += 4;
+    }
+    if event.modifiers.alt {
+        btn += 8;
+    }
+    if event.modifiers.control {
+        btn += 16;
+    }
+
+    // Add motion bit for drag events
+    if matches!(event.event_type, MouseEventType::Drag) {
+        btn += 32;
+    }
+
+    // SGR format: ESC[<btn;col;rowM (press/drag) or m (release)
+    let suffix = match event.event_type {
+        MouseEventType::Press | MouseEventType::Drag => 'M',
+        MouseEventType::Release => 'm',
+    };
+
+    format!("\x1b[<{};{};{}{}", btn, event.col, event.row, suffix).into_bytes()
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -76,6 +76,10 @@ impl Session {
         self.vt.cursor_key_app_mode()
     }
 
+    pub fn size(&self) -> (usize, usize) {
+        self.vt.size()
+    }
+
     pub fn subscribe(&self) -> Subscription {
         let (cols, rows) = self.vt.size();
 


### PR DESCRIPTION
## Summary
Implements mouse event support for the headless terminal, enabling programmatic interaction
with mouse-enabled TUI applications via the JSON STDIN API.

Addresses some of #2

## Motivation
I need mouse support to use `ht` for integration testing of TUI applications. Being able to
programmatically send mouse events (clicks, drags, scrolling) is essential for comprehensive
testing of interactive terminal applications.

## Changes
- Added `mouse` command to STDIN API supporting:
- Event types: `press`, `release`, `drag`, and `click` (convenience shorthand)
- Mouse buttons: `left`, `middle`, `right`, `wheel_up`, `wheel_down`
- Modifier keys: `shift`, `alt`, `control`
- 1-indexed coordinate system matching terminal conventions
- Implemented SGR extended mouse protocol (`\x1b[<` format) for compatibility with modern TUI
apps
- Added coordinate validation with warnings when coordinates exceed terminal bounds
- Comprehensive test coverage for all event types, buttons, and edge cases
- Updated README with detailed documentation and examples

## Example Usage
```json
{ "type": "mouse", "event": "click", "button": "left", "row": 10, "col": 25 }
{ "type": "mouse", "event": "drag", "button": "left", "row": 12, "col": 30 }
{ "type": "mouse", "event": "press", "button": "right", "row": 5, "col": 15, "control": true
}
```

## Caveats

I should note that this PR is somewhat "vibe-coded" - I'm not deeply familiar with Rust, so
there may be idioms or patterns I've missed that would improve the implementation. I'd
appreciate any feedback on code quality, error handling, or areas that could be more
idiomatic. Happy to iterate on the implementation.

## Testing

Manually tested `click` events, using rlwrap with a mouse-enabled TUI application. All unit
tests pass.